### PR TITLE
fix: Remove options preflight and retry failed attempts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### 🐛 Fixed
+- Remove options preflight and retry failed attempts
+

--- a/services/api.js
+++ b/services/api.js
@@ -1,5 +1,8 @@
 import { isEmpty, isPresent } from "../utilities/present.js";
-import { buildFetchFailureContext } from "../utilities/fetchFailureContext.js";
+import {
+  buildFetchFailureContext,
+  mergeCaptureContext,
+} from "../utilities/fetchFailureContext.js";
 
 const MAX_REDIRECTS = 3;
 const MAX_SAFE_FETCH_ATTEMPTS = 2;
@@ -356,46 +359,6 @@ export default class Api {
     return sampleRate >= 1 || Math.random() < sampleRate;
   }
 
-  mergeContexts(contexts = {}, overrideContexts = {}) {
-    return Object.fromEntries(
-      Object.entries({
-        ...contexts,
-        ...overrideContexts,
-      }).map(([key, value]) => {
-        if (
-          contexts[key] != null &&
-          value != null &&
-          typeof contexts[key] === "object" &&
-          typeof value === "object" &&
-          Array.isArray(contexts[key]) === false &&
-          Array.isArray(value) === false
-        ) {
-          return [key, { ...contexts[key], ...value }];
-        }
-
-        return [key, value];
-      }),
-    );
-  }
-
-  mergeCaptureContext(context, overrideContext = {}) {
-    const { extra = {}, tags = {}, contexts = {}, ...rest } = overrideContext;
-
-    return {
-      ...context,
-      ...rest,
-      extra: {
-        ...context.extra,
-        ...extra,
-      },
-      tags: {
-        ...context.tags,
-        ...tags,
-      },
-      contexts: this.mergeContexts(context.contexts, contexts),
-    };
-  }
-
   async fetchResult(url, {
     method = "GET",
     setLoader,
@@ -467,7 +430,7 @@ export default class Api {
               timedOut: abortTimeout.timedOut?.(),
             });
 
-            this.captureException(error, this.mergeCaptureContext(context, captureContext));
+            this.captureException(error, mergeCaptureContext(context, captureContext));
           }
 
           return null;

--- a/services/api.js
+++ b/services/api.js
@@ -238,6 +238,19 @@ export default class Api {
       return;
     }
 
+    const telemetryCaptureContext = {
+      level: "warning",
+      extra: {
+        non_blocking: true,
+        telemetry_event: "offer_viewed",
+      },
+      tags: {
+        "uptick.non_blocking": "true",
+        "uptick.request_importance": "telemetry",
+        "uptick.telemetry_event": "offer_viewed",
+      },
+    };
+
     try {
       let url = new URL(offerResult.links.offer_event);
 
@@ -254,22 +267,17 @@ export default class Api {
         method: "POST",
         setLoader: this.noop,
         parseJson: false,
-        captureContext: {
-          level: "warning",
-          extra: {
-            non_blocking: true,
-            telemetry_event: "offer_viewed",
-          },
-          tags: {
-            "uptick.non_blocking": "true",
-            "uptick.request_importance": "telemetry",
-            "uptick.telemetry_event": "offer_viewed",
-          },
-        },
-        captureSampleRate: OFFER_VIEWED_CAPTURE_SAMPLE_RATE,
+        captureContext: telemetryCaptureContext,
+        captureFailureSampleRate: OFFER_VIEWED_CAPTURE_SAMPLE_RATE,
       });
-    } catch {
+    } catch (error) {
       // Offer-viewed telemetry should not affect rendering or pollute error monitoring.
+      if (this.shouldCaptureFetchFailure(OFFER_VIEWED_CAPTURE_SAMPLE_RATE)) {
+        this.captureException(error, {
+          message: "Offer viewed event failed:",
+          ...telemetryCaptureContext,
+        });
+      }
     }
   }
 
@@ -393,15 +401,16 @@ export default class Api {
     setLoader,
     parseJson = true,
     captureContext = {},
-    captureSampleRate = 1,
+    captureFailureSampleRate = 1,
     retryDelayMs = SAFE_FETCH_RETRY_DELAY_MS,
     fetchTimeoutMs = FETCH_TIMEOUT_MS,
   } = {}) {
     const normalizedMethod = (method ?? "GET").toUpperCase();
     const maxAttempts = normalizedMethod === "GET" ? MAX_SAFE_FETCH_ATTEMPTS : 1;
     const requestUrl = this.urlWithIntegrationParams(url);
+    const updateLoader = typeof setLoader === "function" ? setLoader : this.noop;
 
-    setLoader(true);
+    updateLoader(true);
 
     try {
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -443,7 +452,7 @@ export default class Api {
             continue;
           }
 
-          if (this.shouldCaptureFetchFailure(captureSampleRate)) {
+          if (this.shouldCaptureFetchFailure(captureFailureSampleRate)) {
             const context = buildFetchFailureContext(requestUrl, {
               method: normalizedMethod,
               parseJson,
@@ -469,7 +478,7 @@ export default class Api {
 
       return null;
     } finally {
-      setLoader(false);
+      updateLoader(false);
     }
   }
 }

--- a/services/api.js
+++ b/services/api.js
@@ -2,6 +2,12 @@ import { isEmpty, isPresent } from "../utilities/present.js";
 import { buildFetchFailureContext } from "../utilities/fetchFailureContext.js";
 
 const MAX_REDIRECTS = 3;
+const MAX_SAFE_FETCH_ATTEMPTS = 2;
+const SAFE_FETCH_RETRY_DELAY_MS = 150;
+const OFFER_VIEWED_CAPTURE_SAMPLE_RATE = 0.1;
+const FETCH_TIMEOUT_MS = 8000;
+const INTEGRATION_TYPE = "shopify_extensibility";
+const INTEGRATION_VERSION = "1.1.0";
 
 export default class Api {
   constructor({
@@ -244,9 +250,26 @@ export default class Api {
         this.addParam(url, navigator?.userAgent, "ua"); // User Agent string
       }
 
-      return await this.fetchResult(url.toString(), { method: "POST", setLoader: this.noop, parseJson: false });
-    } catch (error) {
-      this.captureException(error, { extra: { message: "Unable to send offer viewed event" } });
+      return await this.fetchResult(url.toString(), {
+        method: "POST",
+        setLoader: this.noop,
+        parseJson: false,
+        captureContext: {
+          level: "warning",
+          extra: {
+            non_blocking: true,
+            telemetry_event: "offer_viewed",
+          },
+          tags: {
+            "uptick.non_blocking": "true",
+            "uptick.request_importance": "telemetry",
+            "uptick.telemetry_event": "offer_viewed",
+          },
+        },
+        captureSampleRate: OFFER_VIEWED_CAPTURE_SAMPLE_RATE,
+      });
+    } catch {
+      // Offer-viewed telemetry should not affect rendering or pollute error monitoring.
     }
   }
 
@@ -275,42 +298,175 @@ export default class Api {
     }
   }
 
-  async fetchResult(url, { method = "GET", setLoader, parseJson = true }) {
+  retryableFetchFailure({ method, phase, response }) {
+    return method === "GET" && phase === "fetch" && response == null;
+  }
+
+  wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  urlWithIntegrationParams(url) {
+    try {
+      const requestUrl = new URL(url);
+
+      requestUrl.searchParams.set("integration_type", INTEGRATION_TYPE);
+      requestUrl.searchParams.set("integration_version", INTEGRATION_VERSION);
+
+      return requestUrl.toString();
+    } catch {
+      return url;
+    }
+  }
+
+  createAbortTimeout(timeoutMs) {
+    if (timeoutMs == null || timeoutMs <= 0 || typeof AbortController === "undefined") {
+      return {};
+    }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+
+    return {
+      signal: controller.signal,
+      clear: () => clearTimeout(timeoutId),
+      timedOut: () => timedOut,
+    };
+  }
+
+  httpErrorFromResponse(response) {
+    const error = new Error(`Fetch failed with HTTP status ${response.status}`);
+    error.name = "HttpError";
+    return error;
+  }
+
+  shouldCaptureFetchFailure(sampleRate) {
+    return sampleRate >= 1 || Math.random() < sampleRate;
+  }
+
+  mergeContexts(contexts = {}, overrideContexts = {}) {
+    return Object.fromEntries(
+      Object.entries({
+        ...contexts,
+        ...overrideContexts,
+      }).map(([key, value]) => {
+        if (
+          contexts[key] != null &&
+          value != null &&
+          typeof contexts[key] === "object" &&
+          typeof value === "object" &&
+          Array.isArray(contexts[key]) === false &&
+          Array.isArray(value) === false
+        ) {
+          return [key, { ...contexts[key], ...value }];
+        }
+
+        return [key, value];
+      }),
+    );
+  }
+
+  mergeCaptureContext(context, overrideContext = {}) {
+    const { extra = {}, tags = {}, contexts = {}, ...rest } = overrideContext;
+
+    return {
+      ...context,
+      ...rest,
+      extra: {
+        ...context.extra,
+        ...extra,
+      },
+      tags: {
+        ...context.tags,
+        ...tags,
+      },
+      contexts: this.mergeContexts(context.contexts, contexts),
+    };
+  }
+
+  async fetchResult(url, {
+    method = "GET",
+    setLoader,
+    parseJson = true,
+    captureContext = {},
+    captureSampleRate = 1,
+    retryDelayMs = SAFE_FETCH_RETRY_DELAY_MS,
+    fetchTimeoutMs = FETCH_TIMEOUT_MS,
+  } = {}) {
+    const normalizedMethod = (method ?? "GET").toUpperCase();
+    const maxAttempts = normalizedMethod === "GET" ? MAX_SAFE_FETCH_ATTEMPTS : 1;
+    const requestUrl = this.urlWithIntegrationParams(url);
+
     setLoader(true);
-    const startedAt = this.getTimeStamp();
-    let phase = "fetch";
-    let rawResult = null;
 
     try {
-      rawResult = await fetch(url, {
-        method: method ?? "GET",
-        redirect: "follow",
-        cache: "no-cache",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "X-Uptick-Integration-Type": "shopify_extensibility",
-          "X-Uptick-Integration-Version": "1.1.0"
-        }
-      });
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const startedAt = this.getTimeStamp();
+        let phase = "fetch";
+        let rawResult = null;
+        let abortTimeout = {};
 
-      if (parseJson) {
-        phase = "parse_json";
-        return await rawResult.json();
+        try {
+          abortTimeout = this.createAbortTimeout(fetchTimeoutMs);
+          rawResult = await fetch(requestUrl, {
+            method: normalizedMethod,
+            redirect: "follow",
+            cache: "no-cache",
+            signal: abortTimeout.signal,
+            headers: {
+              Accept: "application/json",
+            }
+          });
+
+          if (rawResult?.ok === false) {
+            phase = "http_status";
+            throw this.httpErrorFromResponse(rawResult);
+          }
+
+          if (parseJson) {
+            phase = "parse_json";
+            return await rawResult.json();
+          }
+
+          phase = "read_body";
+          return rawResult.body;
+        } catch (error) {
+          if (
+            attempt < maxAttempts &&
+            this.retryableFetchFailure({ method: normalizedMethod, phase, response: rawResult })
+          ) {
+            await this.wait(retryDelayMs);
+            continue;
+          }
+
+          if (this.shouldCaptureFetchFailure(captureSampleRate)) {
+            const context = buildFetchFailureContext(requestUrl, {
+              method: normalizedMethod,
+              parseJson,
+              phase,
+              startedAt,
+              endedAt: this.getTimeStamp(),
+              error,
+              response: rawResult,
+              attempt,
+              retried: attempt > 1,
+              timeoutMs: fetchTimeoutMs,
+              timedOut: abortTimeout.timedOut?.(),
+            });
+
+            this.captureException(error, this.mergeCaptureContext(context, captureContext));
+          }
+
+          return null;
+        } finally {
+          abortTimeout.clear?.();
+        }
       }
 
-      phase = "read_body";
-      return rawResult.body;
-    } catch (error) {
-      this.captureException(error, buildFetchFailureContext(url, {
-        method,
-        parseJson,
-        phase,
-        startedAt,
-        endedAt: this.getTimeStamp(),
-        error,
-        response: rawResult,
-      }));
       return null;
     } finally {
       setLoader(false);

--- a/services/api.test.js
+++ b/services/api.test.js
@@ -9,6 +9,27 @@ import Api from "./api";
 import { isPresent } from "../utilities/present";
 
 const offerUrlBase = "https://api.uptick.com/v1/places/place-id/flows/flow-id/offers/new?event_id=event-id&index=0";
+const integrationType = "shopify_extensibility";
+const integrationVersion = "1.1.0";
+
+function fetchUrl(url) {
+  const requestUrl = new URL(url);
+  requestUrl.searchParams.set("integration_type", integrationType);
+  requestUrl.searchParams.set("integration_version", integrationVersion);
+  return requestUrl.toString();
+}
+
+function fetchOptions(method) {
+  return {
+    method,
+    redirect: "follow",
+    cache: "no-cache",
+    signal: expect.any(Object),
+    headers: {
+      Accept: "application/json",
+    }
+  };
+}
 
 function createApi(includeShopApi = true, { integrationId = null, includeShippingAddress = true, options = {} } = {}) {
   const shopApi = {
@@ -894,7 +915,24 @@ describe("api", () => {
       url.searchParams.append("ua", "Chrome");
 
       expect(api.fetchResult).toHaveBeenCalledTimes(1);
-      expect(api.fetchResult).toHaveBeenCalledWith(url.toString(), { method: "POST", setLoader: api.noop, parseJson: false });
+      expect(api.fetchResult).toHaveBeenCalledWith(url.toString(), {
+        method: "POST",
+        setLoader: api.noop,
+        parseJson: false,
+        captureContext: {
+          level: "warning",
+          extra: {
+            non_blocking: true,
+            telemetry_event: "offer_viewed",
+          },
+          tags: {
+            "uptick.non_blocking": "true",
+            "uptick.request_importance": "telemetry",
+            "uptick.telemetry_event": "offer_viewed",
+          },
+        },
+        captureSampleRate: 0.1,
+      });
 
       expect(api.setLoading).toHaveBeenCalledTimes(0);
       expect(api.captureException).toHaveBeenCalledTimes(0);
@@ -957,7 +995,7 @@ describe("api", () => {
       expect(api.captureWarning).toHaveBeenCalledWith("Unable to find offer event link from offer.");
     });
 
-    test("catches and reports fetch errors", async () => {
+    test("silently ignores unexpected telemetry rejections", async () => {
       const api = createApi();
       const fetchError = new Error("Network failure");
       jest.spyOn(api, "fetchResult").mockRejectedValue(fetchError);
@@ -970,8 +1008,7 @@ describe("api", () => {
 
       await api.offerViewedEvent(offerResult);
 
-      expect(api.captureException).toHaveBeenCalledTimes(1);
-      expect(api.captureException).toHaveBeenCalledWith(fetchError, { extra: { message: "Unable to send offer viewed event" } });
+      expect(api.captureException).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -993,17 +1030,7 @@ describe("api", () => {
       expect(result).toStrictEqual({ test: 100 });
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith("https://www.test.com", {
-        method: "POST",
-        redirect: "follow",
-        cache: "no-cache",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "X-Uptick-Integration-Type": "shopify_extensibility",
-          "X-Uptick-Integration-Version": "1.1.0"
-        }
-      });
+      expect(global.fetch).toHaveBeenCalledWith(fetchUrl("https://www.test.com"), fetchOptions("POST"));
 
       expect(api.setLoading).toHaveBeenCalledTimes(2);
       expect(api.setLoading.mock.calls[0][0]).toBe(true);
@@ -1029,17 +1056,7 @@ describe("api", () => {
       expect(result).toBeNull();
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith("https://www.test.com", {
-        method: "POST",
-        redirect: "follow",
-        cache: "no-cache",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "X-Uptick-Integration-Type": "shopify_extensibility",
-          "X-Uptick-Integration-Version": "1.1.0"
-        }
-      });
+      expect(global.fetch).toHaveBeenCalledWith(fetchUrl("https://www.test.com"), fetchOptions("POST"));
 
       expect(api.setLoading).toHaveBeenCalledTimes(2);
       expect(api.setLoading.mock.calls[0][0]).toBe(true);
@@ -1049,11 +1066,15 @@ describe("api", () => {
       expect(api.captureException).toHaveBeenCalledWith("failed", {
         message: "Fetch failed:",
         extra: expect.objectContaining({
-          url: "https://www.test.com",
+          url: "https://www.test.com/",
           method: "POST",
           parse_json: true,
           request_phase: "parse_json",
+          request_attempts: 1,
+          request_retried: false,
           request_type: "unknown",
+          url_integration_type: integrationType,
+          url_integration_version: integrationVersion,
           url_host: "www.test.com",
           url_origin: "https://www.test.com",
           url_path: "/",
@@ -1061,6 +1082,7 @@ describe("api", () => {
         tags: expect.objectContaining({
           "uptick.fetch_error": "string",
           "uptick.fetch_host": "www.test.com",
+          "uptick.request_retried": "false",
           "uptick.request_phase": "parse_json",
           "uptick.request_type": "unknown",
         }),
@@ -1069,11 +1091,238 @@ describe("api", () => {
             method: "POST",
             parse_json: true,
             phase: "parse_json",
+            attempts: 1,
+            retried: false,
             request_type: "unknown",
+            url_integration_type: integrationType,
+            url_integration_version: integrationVersion,
             url_host: "www.test.com",
           }),
         }),
       });
+    });
+
+    test("retries GET fetch failures without capturing when retry succeeds", async() => {
+      global.fetch = jest.fn()
+        .mockRejectedValueOnce(new TypeError("Load failed"))
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve({ test: 100 }),
+        });
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      const result = await api.fetchResult("https://www.test.com", {
+        setLoader: api.setLoading,
+        retryDelayMs: 0,
+      });
+
+      expect(result).toStrictEqual({ test: 100 });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(1, fetchUrl("https://www.test.com"), fetchOptions("GET"));
+      expect(global.fetch).toHaveBeenNthCalledWith(2, fetchUrl("https://www.test.com"), fetchOptions("GET"));
+      expect(api.setLoading).toHaveBeenCalledTimes(2);
+      expect(api.setLoading.mock.calls[0][0]).toBe(true);
+      expect(api.setLoading.mock.calls[1][0]).toBe(false);
+      expect(api.captureException).toHaveBeenCalledTimes(0);
+    });
+
+    test("captures GET fetch failures only after the retry fails", async() => {
+      const firstError = new TypeError("Load failed");
+      const finalError = new TypeError("Load failed again");
+      global.fetch = jest.fn()
+        .mockRejectedValueOnce(firstError)
+        .mockRejectedValueOnce(finalError);
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      const result = await api.fetchResult("https://www.test.com", {
+        setLoader: api.setLoading,
+        retryDelayMs: 0,
+      });
+
+      expect(result).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(api.setLoading).toHaveBeenCalledTimes(2);
+      expect(api.setLoading.mock.calls[0][0]).toBe(true);
+      expect(api.setLoading.mock.calls[1][0]).toBe(false);
+      expect(api.captureException).toHaveBeenCalledTimes(1);
+      expect(api.captureException).toHaveBeenCalledWith(finalError, {
+        message: "Fetch failed:",
+        extra: expect.objectContaining({
+          url: "https://www.test.com/",
+          method: "GET",
+          parse_json: true,
+          request_phase: "fetch",
+          request_attempts: 2,
+          request_retried: true,
+          request_type: "unknown",
+          url_integration_type: integrationType,
+          url_integration_version: integrationVersion,
+          url_host: "www.test.com",
+        }),
+        tags: expect.objectContaining({
+          "uptick.fetch_error": "TypeError",
+          "uptick.fetch_host": "www.test.com",
+          "uptick.request_phase": "fetch",
+          "uptick.request_retried": "true",
+          "uptick.request_type": "unknown",
+        }),
+        contexts: expect.objectContaining({
+          fetch_request: expect.objectContaining({
+            method: "GET",
+            parse_json: true,
+            phase: "fetch",
+            attempts: 2,
+            retried: true,
+            request_type: "unknown",
+            url_integration_type: integrationType,
+            url_integration_version: integrationVersion,
+            url_host: "www.test.com",
+          }),
+        }),
+      });
+    });
+
+    test("merges custom capture context into fetch failures", async() => {
+      const error = new TypeError("Telemetry fetch failed");
+      global.fetch = jest.fn().mockRejectedValue(error);
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      const result = await api.fetchResult("https://www.test.com/events", {
+        method: "POST",
+        setLoader: api.setLoading,
+        captureContext: {
+          level: "warning",
+          extra: {
+            non_blocking: true,
+            telemetry_event: "offer_viewed",
+          },
+          tags: {
+            "uptick.non_blocking": "true",
+            "uptick.request_importance": "telemetry",
+            "uptick.telemetry_event": "offer_viewed",
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(api.captureException).toHaveBeenCalledTimes(1);
+      expect(api.captureException).toHaveBeenCalledWith(error, expect.objectContaining({
+        level: "warning",
+        extra: expect.objectContaining({
+          non_blocking: true,
+          telemetry_event: "offer_viewed",
+          request_type: "offer_event",
+        }),
+        tags: expect.objectContaining({
+          "uptick.non_blocking": "true",
+          "uptick.request_importance": "telemetry",
+          "uptick.telemetry_event": "offer_viewed",
+          "uptick.request_type": "offer_event",
+        }),
+      }));
+    });
+
+    test("captures non-ok HTTP responses without parsing the body", async() => {
+      const json = jest.fn();
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        url: "https://www.test.com/events?first_name=Hidden&zip=12345",
+        type: "cors",
+        redirected: false,
+        json,
+      });
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      const result = await api.fetchResult("https://www.test.com/events?first_name=Hidden&zip=12345", {
+        setLoader: api.setLoading,
+      });
+
+      expect(result).toBeNull();
+      expect(json).toHaveBeenCalledTimes(0);
+      expect(api.captureException).toHaveBeenCalledTimes(1);
+
+      const [error, context] = api.captureException.mock.calls[0];
+      expect(error.name).toBe("HttpError");
+      expect(error.message).toBe("Fetch failed with HTTP status 500");
+      expect(context).toStrictEqual(expect.objectContaining({
+        message: "Fetch failed:",
+        extra: expect.objectContaining({
+          url: "https://www.test.com/events",
+          response_status: 500,
+          response_status_text: "Server Error",
+          response_url: "https://www.test.com/events",
+          request_phase: "http_status",
+          request_type: "offer_event",
+        }),
+        tags: expect.objectContaining({
+          "uptick.fetch_error": "HttpError",
+          "uptick.request_phase": "http_status",
+          "uptick.request_type": "offer_event",
+        }),
+      }));
+      expect(JSON.stringify(context)).not.toContain("Hidden");
+      expect(JSON.stringify(context)).not.toContain("12345");
+    });
+
+    test("passes an abort signal to fetch so stalled requests can time out", async() => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ test: 100 }),
+        }),
+      );
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      await api.fetchResult("https://www.test.com", {
+        setLoader: api.setLoading,
+        fetchTimeoutMs: 50,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(fetchUrl("https://www.test.com"), fetchOptions("GET"));
+      const fetchOptionsArg = global.fetch.mock.calls[0][1];
+      expect(fetchOptionsArg.signal.aborted).toBe(false);
+    });
+
+    test("marks abort timeout state when the timeout fires", () => {
+      jest.useFakeTimers();
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      try {
+        const abortTimeout = api.createAbortTimeout(50);
+
+        expect(abortTimeout.signal.aborted).toBe(false);
+        expect(abortTimeout.timedOut()).toBe(false);
+
+        jest.advanceTimersByTime(50);
+
+        expect(abortTimeout.signal.aborted).toBe(true);
+        expect(abortTimeout.timedOut()).toBe(true);
+        abortTimeout.clear();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test("skips capture when fetch failure sampling excludes the event", async() => {
+      global.fetch = jest.fn().mockRejectedValue(new TypeError("Sampled out"));
+
+      const api = createApi({ captureException: jest.fn((x) => x) });
+
+      const result = await api.fetchResult("https://www.test.com", {
+        method: "POST",
+        setLoader: api.setLoading,
+        captureSampleRate: 0,
+      });
+
+      expect(result).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(api.captureException).toHaveBeenCalledTimes(0);
     });
 
     test("still captures fetch errors when failure context building throws", async() => {
@@ -1113,10 +1362,12 @@ describe("api", () => {
         expect(api.captureException).toHaveBeenCalledWith(fetchError, {
           message: "Fetch failed:",
           extra: expect.objectContaining({
-            url: "https://www.test.com",
+            url: "https://www.test.com/",
             method: "POST",
             parse_json: true,
             request_phase: "parse_json",
+            request_attempts: 1,
+            request_retried: false,
             fetch_context_error_message: "connection unavailable",
           }),
           tags: expect.objectContaining({
@@ -1131,6 +1382,8 @@ describe("api", () => {
               method: "POST",
               parse_json: true,
               phase: "parse_json",
+              attempts: 1,
+              retried: false,
             }),
           }),
         });

--- a/services/api.test.js
+++ b/services/api.test.js
@@ -931,7 +931,7 @@ describe("api", () => {
             "uptick.telemetry_event": "offer_viewed",
           },
         },
-        captureSampleRate: 0.1,
+        captureFailureSampleRate: 0.1,
       });
 
       expect(api.setLoading).toHaveBeenCalledTimes(0);
@@ -995,10 +995,11 @@ describe("api", () => {
       expect(api.captureWarning).toHaveBeenCalledWith("Unable to find offer event link from offer.");
     });
 
-    test("silently ignores unexpected telemetry rejections", async () => {
+    test("samples unexpected telemetry rejections without blocking", async () => {
       const api = createApi();
       const fetchError = new Error("Network failure");
       jest.spyOn(api, "fetchResult").mockRejectedValue(fetchError);
+      const random = jest.spyOn(Math, "random").mockReturnValue(0.05);
 
       const offerResult = {
         links: {
@@ -1006,9 +1007,48 @@ describe("api", () => {
         }
       };
 
-      await api.offerViewedEvent(offerResult);
+      try {
+        await api.offerViewedEvent(offerResult);
 
-      expect(api.captureException).toHaveBeenCalledTimes(0);
+        expect(api.captureException).toHaveBeenCalledTimes(1);
+        expect(api.captureException).toHaveBeenCalledWith(fetchError, {
+          message: "Offer viewed event failed:",
+          level: "warning",
+          extra: {
+            non_blocking: true,
+            telemetry_event: "offer_viewed",
+          },
+          tags: {
+            "uptick.non_blocking": "true",
+            "uptick.request_importance": "telemetry",
+            "uptick.telemetry_event": "offer_viewed",
+          },
+        });
+      } finally {
+        random.mockRestore();
+      }
+    });
+
+    test("samples out offer viewed fetch failures", async() => {
+      global.fetch = jest.fn().mockRejectedValue(new TypeError("Sampled out"));
+      const random = jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+      const api = createApi();
+      const offerResult = {
+        links: {
+          offer_event: "https://api.uptick.com/v1/places/place-id/flows/flow-id/events?eid=event-id"
+        }
+      };
+
+      try {
+        const result = await api.offerViewedEvent(offerResult);
+
+        expect(result).toBeNull();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(api.captureException).toHaveBeenCalledTimes(0);
+      } finally {
+        random.mockRestore();
+      }
     });
   });
 
@@ -1036,6 +1076,24 @@ describe("api", () => {
       expect(api.setLoading.mock.calls[0][0]).toBe(true);
       expect(api.setLoading.mock.calls[1][0]).toBe(false);
 
+      expect(api.captureException).toHaveBeenCalledTimes(0);
+    });
+
+    test("uses noop loader when setLoader is omitted", async() => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ test: 100 }),
+        }),
+      );
+
+      const api = createApi();
+
+      const result = await api.fetchResult("https://www.test.com");
+
+      expect(result).toStrictEqual({ test: 100 });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(fetchUrl("https://www.test.com"), fetchOptions("GET"));
+      expect(api.setLoading).toHaveBeenCalledTimes(0);
       expect(api.captureException).toHaveBeenCalledTimes(0);
     });
 
@@ -1307,22 +1365,6 @@ describe("api", () => {
       } finally {
         jest.useRealTimers();
       }
-    });
-
-    test("skips capture when fetch failure sampling excludes the event", async() => {
-      global.fetch = jest.fn().mockRejectedValue(new TypeError("Sampled out"));
-
-      const api = createApi({ captureException: jest.fn((x) => x) });
-
-      const result = await api.fetchResult("https://www.test.com", {
-        method: "POST",
-        setLoader: api.setLoading,
-        captureSampleRate: 0,
-      });
-
-      expect(result).toBeNull();
-      expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(api.captureException).toHaveBeenCalledTimes(0);
     });
 
     test("still captures fetch errors when failure context building throws", async() => {

--- a/utilities/fetchFailureContext.js
+++ b/utilities/fetchFailureContext.js
@@ -4,6 +4,38 @@ export function compactObject(object) {
   );
 }
 
+export function mergeCaptureContext(baseContext = {}, overrideContext = {}) {
+  const {
+    extra: baseExtra = {},
+    tags: baseTags = {},
+    contexts: baseContexts = {},
+    ...baseRest
+  } = baseContext || {};
+  const {
+    extra = {},
+    tags = {},
+    contexts = {},
+    ...rest
+  } = overrideContext || {};
+
+  return {
+    ...baseRest,
+    ...rest,
+    extra: compactObject({
+      ...baseExtra,
+      ...extra,
+    }),
+    tags: compactObject({
+      ...baseTags,
+      ...tags,
+    }),
+    contexts: {
+      ...baseContexts,
+      ...contexts,
+    },
+  };
+}
+
 export function sanitizedUrl(urlString) {
   try {
     const url = new URL(urlString);

--- a/utilities/fetchFailureContext.js
+++ b/utilities/fetchFailureContext.js
@@ -4,6 +4,16 @@ export function compactObject(object) {
   );
 }
 
+export function sanitizedUrl(urlString) {
+  try {
+    const url = new URL(urlString);
+
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function inferRequestType(url) {
   const pathParts = url.pathname.split("/").filter(Boolean);
 
@@ -35,6 +45,8 @@ export function requestUrlContext(urlString) {
       url_placement: url.searchParams.get("placement") || undefined,
       url_shop_myshopify_domain: url.searchParams.get("shop_myshopify_domain") || undefined,
       url_no_redirect: url.searchParams.get("no_redirect") || undefined,
+      url_integration_type: url.searchParams.get("integration_type") || undefined,
+      url_integration_version: url.searchParams.get("integration_version") || undefined,
     });
   } catch {
     return {
@@ -70,7 +82,19 @@ export function navigatorContext() {
 }
 
 export function buildFetchFailureContext(url, options = {}) {
-  const { method, parseJson, phase, startedAt, endedAt, error, response } = options;
+  const {
+    method,
+    parseJson,
+    phase,
+    startedAt,
+    endedAt,
+    error,
+    response,
+    attempt,
+    retried,
+    timeoutMs,
+    timedOut,
+  } = options;
   const elapsedMs = startedAt == null || endedAt == null ? undefined : endedAt - startedAt;
 
   try {
@@ -79,16 +103,20 @@ export function buildFetchFailureContext(url, options = {}) {
     const responseContext = compactObject({
       response_status: response?.status,
       response_status_text: response?.statusText,
-      response_url: response?.url,
+      response_url: sanitizedUrl(response?.url),
       response_type: response?.type,
       response_redirected: response?.redirected,
     });
     const extra = compactObject({
-      url,
+      url: sanitizedUrl(url),
       method,
       parse_json: parseJson,
       request_phase: phase,
       request_elapsed_ms: elapsedMs,
+      request_attempts: attempt,
+      request_retried: retried,
+      request_timeout_ms: timeoutMs,
+      request_timed_out: timedOut,
       ...requestContext,
       ...responseContext,
       ...errorContext(error),
@@ -104,6 +132,8 @@ export function buildFetchFailureContext(url, options = {}) {
         "uptick.fetch_host": requestContext.url_host,
         "uptick.fetch_error": error?.name || typeof error,
         "uptick.navigator_online": runtimeContext.navigator_online == null ? undefined : String(runtimeContext.navigator_online),
+        "uptick.request_retried": retried == null ? undefined : String(retried),
+        "uptick.request_timed_out": timedOut == null ? undefined : String(timedOut),
       }),
       contexts: {
         fetch_request: compactObject({
@@ -111,6 +141,10 @@ export function buildFetchFailureContext(url, options = {}) {
           parse_json: parseJson,
           phase,
           elapsed_ms: elapsedMs,
+          attempts: attempt,
+          retried,
+          timeout_ms: timeoutMs,
+          timed_out: timedOut,
           ...requestContext,
         }),
         fetch_runtime: runtimeContext,
@@ -121,17 +155,23 @@ export function buildFetchFailureContext(url, options = {}) {
     return {
       message: "Fetch failed:",
       extra: compactObject({
-        url,
+        url: sanitizedUrl(url),
         method,
         parse_json: parseJson,
         request_phase: phase,
         request_elapsed_ms: elapsedMs,
+        request_attempts: attempt,
+        request_retried: retried,
+        request_timeout_ms: timeoutMs,
+        request_timed_out: timedOut,
         fetch_context_error_name: contextError?.name,
         fetch_context_error_message: contextError?.message,
       }),
       tags: compactObject({
         "uptick.request_phase": phase,
         "uptick.fetch_context_error": contextError?.name || typeof contextError,
+        "uptick.request_retried": retried == null ? undefined : String(retried),
+        "uptick.request_timed_out": timedOut == null ? undefined : String(timedOut),
       }),
       contexts: {
         fetch_request: compactObject({
@@ -139,6 +179,10 @@ export function buildFetchFailureContext(url, options = {}) {
           parse_json: parseJson,
           phase,
           elapsed_ms: elapsedMs,
+          attempts: attempt,
+          retried,
+          timeout_ms: timeoutMs,
+          timed_out: timedOut,
         }),
         fetch_context_error: compactObject({
           name: contextError?.name,

--- a/utilities/fetchFailureContext.test.js
+++ b/utilities/fetchFailureContext.test.js
@@ -8,6 +8,7 @@ import {
   buildFetchFailureContext,
   errorContext,
   inferRequestType,
+  mergeCaptureContext,
   navigatorContext,
   requestUrlContext,
 } from "./fetchFailureContext";
@@ -16,6 +17,76 @@ const originalNavigator = global.navigator;
 
 afterEach(() => {
   global.navigator = originalNavigator;
+});
+
+describe("mergeCaptureContext", () => {
+  test("merges top-level context and Sentry data bags", () => {
+    expect(mergeCaptureContext(
+      {
+        message: "Fetch failed:",
+        extra: {
+          method: "GET",
+          request_type: "offer",
+        },
+        tags: {
+          "uptick.request_type": "offer",
+        },
+        contexts: {
+          fetch_request: {
+            method: "GET",
+          },
+        },
+      },
+      {
+        level: "warning",
+        extra: {
+          non_blocking: true,
+        },
+        tags: {
+          "uptick.request_importance": "telemetry",
+        },
+      },
+    )).toStrictEqual({
+      message: "Fetch failed:",
+      level: "warning",
+      extra: {
+        method: "GET",
+        request_type: "offer",
+        non_blocking: true,
+      },
+      tags: {
+        "uptick.request_type": "offer",
+        "uptick.request_importance": "telemetry",
+      },
+      contexts: {
+        fetch_request: {
+          method: "GET",
+        },
+      },
+    });
+  });
+
+  test("replaces named contexts instead of deep merging them", () => {
+    expect(mergeCaptureContext(
+      {
+        contexts: {
+          fetch_request: {
+            method: "GET",
+            phase: "fetch",
+          },
+        },
+      },
+      {
+        contexts: {
+          fetch_request: {
+            purpose: "override",
+          },
+        },
+      },
+    ).contexts.fetch_request).toStrictEqual({
+      purpose: "override",
+    });
+  });
 });
 
 describe("inferRequestType", () => {

--- a/utilities/fetchFailureContext.test.js
+++ b/utilities/fetchFailureContext.test.js
@@ -98,33 +98,56 @@ describe("buildFetchFailureContext", () => {
   test("builds capture context for fetch failures", () => {
     delete global.navigator;
 
-    const context = buildFetchFailureContext("https://www.test.com", {
-      method: "POST",
-      parseJson: true,
-      phase: "parse_json",
-      startedAt: 1000,
-      endedAt: 1250,
-      error: "failed",
-    });
+    const context = buildFetchFailureContext(
+      "https://www.test.com/offers/new?first_name=Hidden&zip=12345&integration_type=shopify_extensibility&integration_version=1.1.0",
+      {
+        method: "POST",
+        parseJson: true,
+        phase: "parse_json",
+        startedAt: 1000,
+        endedAt: 1250,
+        error: "failed",
+        response: {
+          status: 500,
+          statusText: "Server Error",
+          url: "https://www.test.com/offers/new?first_name=Hidden&zip=12345",
+        },
+        attempt: 2,
+        retried: true,
+        timeoutMs: 8000,
+        timedOut: false,
+      },
+    );
 
     expect(context).toStrictEqual({
       message: "Fetch failed:",
       extra: {
-        url: "https://www.test.com",
+        url: "https://www.test.com/offers/new",
         method: "POST",
         parse_json: true,
         request_phase: "parse_json",
         request_elapsed_ms: 250,
-        request_type: "unknown",
+        request_attempts: 2,
+        request_retried: true,
+        request_timeout_ms: 8000,
+        request_timed_out: false,
+        request_type: "offer",
+        response_status: 500,
+        response_status_text: "Server Error",
+        response_url: "https://www.test.com/offers/new",
         url_origin: "https://www.test.com",
         url_host: "www.test.com",
-        url_path: "/",
+        url_path: "/offers/new",
+        url_integration_type: "shopify_extensibility",
+        url_integration_version: "1.1.0",
       },
       tags: {
-        "uptick.request_type": "unknown",
+        "uptick.request_type": "offer",
         "uptick.request_phase": "parse_json",
         "uptick.fetch_host": "www.test.com",
         "uptick.fetch_error": "string",
+        "uptick.request_retried": "true",
+        "uptick.request_timed_out": "false",
       },
       contexts: {
         fetch_request: {
@@ -132,14 +155,26 @@ describe("buildFetchFailureContext", () => {
           parse_json: true,
           phase: "parse_json",
           elapsed_ms: 250,
-          request_type: "unknown",
+          attempts: 2,
+          retried: true,
+          timeout_ms: 8000,
+          timed_out: false,
+          request_type: "offer",
           url_origin: "https://www.test.com",
           url_host: "www.test.com",
-          url_path: "/",
+          url_path: "/offers/new",
+          url_integration_type: "shopify_extensibility",
+          url_integration_version: "1.1.0",
         },
         fetch_runtime: {},
-        fetch_response: {},
+        fetch_response: {
+          response_status: 500,
+          response_status_text: "Server Error",
+          response_url: "https://www.test.com/offers/new",
+        },
       },
     });
+    expect(JSON.stringify(context)).not.toContain("Hidden");
+    expect(JSON.stringify(context)).not.toContain("12345");
   });
 });


### PR DESCRIPTION
This simplifies the request process and removes the need for the OPTIONS preflight. It also includes a retry mechanism to better handle failed or dropped requests automatically. 